### PR TITLE
Update README.md for new location of export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This extension is only available for Chrome, as it uses the local storage API to
 
 **To install,** please visit the [Chrome Webstore](https://chrome.google.com/webstore/detail/r20exporter/apbhfinbjilbkljgcnjjagecnciphnoi)
 
-To export your campaign go to the settings tab in the Roll20 page (the gear icon on the far right of the sidebar) and at the top you should see a button "**Export Campaign to ZIP**". Simply click on it, then wait until the ZIP file is generated and downloaded.
+To export your campaign go to the settings tab in the Roll20 page (the gear icon on the far right of the sidebar), click to expand the "R20Exporter" section, and you should see a button "**Export Campaign to ZIP**". Simply click on it, then wait until the ZIP file is generated and downloaded.
 
 While generating the ZIP file, do make sure you have the campaign tab focused in chrome (separate it in its own window if needed), otherwise the download speed of the zip will drop to very very slow transfer speeds since the javascript that generates the zip on the fly will be running as a low priority background process.
 


### PR DESCRIPTION
Here's where I found the button after installing v0.9.6:
![image](https://github.com/kakaroto/R20Exporter/assets/687269/fc2055b5-7fce-4a46-96c9-c9874af1ddf2)